### PR TITLE
rename package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "ripple-lib",
+  "name": "@ledhed2222/ripple-lib",
   "version": "1.10.0",
   "license": "ISC",
-  "description": "A TypeScript/JavaScript API for interacting with the XRP Ledger in Node.js and the browser",
+  "description": "Experimental fork of ripple-lib",
   "files": [
     "dist/npm/*",
     "build/ripple-latest-min.js",


### PR DESCRIPTION
renames this package to `@ledhed2222/ripple-lib` so it can be temporarily published to npm