### PR TITLE
remove "data-urls" dependency and use a regex to validate a data URI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ripple-lib",
       "version": "1.10.0",
       "license": "ISC",
       "dependencies": {
@@ -12,7 +13,6 @@
         "@types/ws": "^7.2.0",
         "axios": "^0.21.1",
         "bignumber.js": "^9.0.0",
-        "data-urls": "^3.0.0",
         "https-proxy-agent": "^5.0.0",
         "jsonschema": "1.2.2",
         "lodash": "^4.17.4",
@@ -1004,11 +1004,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
-    "node_modules/abab": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
-    },
     "node_modules/acorn": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
@@ -1962,19 +1957,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/data-urls": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.0.tgz",
-      "integrity": "sha512-4AefxbTTdFtxDUdh0BuMBs2qJVL25Mow2zlcuuePegQwgD6GEmQao42LLEeksOui8nL4RcNEugIpFP7eRd33xg==",
-      "dependencies": {
-        "abab": "^2.0.3",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/debug": {
@@ -6235,25 +6217,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tr46": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tr46/node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
@@ -6682,14 +6645,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
-      "engines": {
-        "node": ">=10.4"
-      }
-    },
     "node_modules/webpack": {
       "version": "5.48.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.48.0.tgz",
@@ -6846,23 +6801,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-9.1.0.tgz",
-      "integrity": "sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==",
-      "dependencies": {
-        "tr46": "^2.1.0",
-        "webidl-conversions": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -7960,11 +7898,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
-    "abab": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
-    },
     "acorn": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
@@ -8718,16 +8651,6 @@
         "public-encrypt": "^4.0.0",
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
-      }
-    },
-    "data-urls": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.0.tgz",
-      "integrity": "sha512-4AefxbTTdFtxDUdh0BuMBs2qJVL25Mow2zlcuuePegQwgD6GEmQao42LLEeksOui8nL4RcNEugIpFP7eRd33xg==",
-      "requires": {
-        "abab": "^2.0.3",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^9.0.0"
       }
     },
     "debug": {
@@ -11940,21 +11863,6 @@
       "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
       "dev": true
     },
-    "tr46": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
-      "requires": {
-        "punycode": "^2.1.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-        }
-      }
-    },
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
@@ -12284,11 +12192,6 @@
         "graceful-fs": "^4.1.2"
       }
     },
-    "webidl-conversions": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
-    },
     "webpack": {
       "version": "5.48.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.48.0.tgz",
@@ -12394,20 +12297,6 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz",
       "integrity": "sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==",
       "dev": true
-    },
-    "whatwg-mimetype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
-    },
-    "whatwg-url": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-9.1.0.tgz",
-      "integrity": "sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==",
-      "requires": {
-        "tr46": "^2.1.0",
-        "webidl-conversions": "^6.1.0"
-      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@types/ws": "^7.2.0",
     "axios": "^0.21.1",
     "bignumber.js": "^9.0.0",
-    "data-urls": "^3.0.0",
     "https-proxy-agent": "^5.0.0",
     "jsonschema": "1.2.2",
     "lodash": "^4.17.4",

--- a/src/ledger/nftoken.ts
+++ b/src/ledger/nftoken.ts
@@ -43,7 +43,7 @@ const validateOnLedger = (
 }
 
 const isDataUriValid = (uri: string): boolean => {
-  const regex = /data:([-\w]+\/[-+\w.]+)?(;?[\w]+=[-\w]+)*(;base64)?,.*/gu
+  const regex = /data:([-\w]+\/[-+\w.]+)?(;?\w+=[-\w]+)*(;base64)?,.*/gu
   return regex.test(uri)
 }
 

--- a/src/ledger/nftoken.ts
+++ b/src/ledger/nftoken.ts
@@ -44,7 +44,7 @@ const validateOnLedger = (
 
 const isDataUriValid = (uri: string): boolean => {
   const regex = /^data:([-\w]+\/[-+\w.]+)?((?:;?[\w]+=[-\w]+)*)(;base64)?,(.*)/
-  return regex.test(uri.trim())
+  return regex.test(uri)
 }
 
 const validateCentralizedOffLedger = async (

--- a/src/ledger/nftoken.ts
+++ b/src/ledger/nftoken.ts
@@ -1,5 +1,4 @@
 import axios from 'axios'
-import parseDataUri from 'data-urls'
 import toml from 'toml'
 
 import {RippleAPI} from '..'
@@ -38,9 +37,14 @@ const validateOnLedger = (
   }
 
   // Confirm that URI is a correctly-encoded data URI
-  if (parseDataUri(uri) == null) {
+  if (isDataUriValid(uri)) {
     throw new ValidationError(`${uri} is not a correctly-encoded data URI, as recommended`)
   }
+}
+
+const isDataUriValid = (uri: string): boolean => {
+  const regex = /^data:([-\w]+\/[-+\w.]+)?((?:;?[\w]+=[-\w]+)*)(;base64)?,(.*)/
+  return regex.test(uri.trim())
 }
 
 const validateCentralizedOffLedger = async (

--- a/src/ledger/nftoken.ts
+++ b/src/ledger/nftoken.ts
@@ -37,7 +37,7 @@ const validateOnLedger = (
   }
 
   // Confirm that URI is a correctly-encoded data URI
-  if (isDataUriValid(uri)) {
+  if (!isDataUriValid(uri)) {
     throw new ValidationError(`${uri} is not a correctly-encoded data URI, as recommended`)
   }
 }

--- a/src/ledger/nftoken.ts
+++ b/src/ledger/nftoken.ts
@@ -43,7 +43,7 @@ const validateOnLedger = (
 }
 
 const isDataUriValid = (uri: string): boolean => {
-  const regex = /^data:([-\w]+\/[-+\w.]+)?((?:;?[\w]+=[-\w]+)*)(;base64)?,(.*)/
+  const regex = /data:([-\w]+\/[-+\w.]+)?(;?[\w]+=[-\w]+)*(;base64)?,.*/g
   return regex.test(uri)
 }
 

--- a/src/ledger/nftoken.ts
+++ b/src/ledger/nftoken.ts
@@ -43,7 +43,7 @@ const validateOnLedger = (
 }
 
 const isDataUriValid = (uri: string): boolean => {
-  const regex = /data:([-\w]+\/[-+\w.]+)?(;?[\w]+=[-\w]+)*(;base64)?,.*/g
+  const regex = /data:([-\w]+\/[-+\w.]+)?(;?[\w]+=[-\w]+)*(;base64)?,.*/gu
   return regex.test(uri)
 }
 


### PR DESCRIPTION
## High Level Overview of Change

Removes "data-urls" dependency and instead uses a regex to validate a data URI

### Context of Change

- "data-urls" is an npm package used to validate a data URI.
- Since it's throwing an error with one of its dependencies, we need to remove it. 
- Its usage has been replaced with a regex to validate a data URI

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Refactor (non-breaking change that only restructures code)

## Test Plan

Need to confirm if these should be added later but I tested the regex using this - https://regexr.com/65jqo